### PR TITLE
Access to the path '<nugetcache>\xunitcontext\3.1.0\build\XunitContext.targets' is denied

### DIFF
--- a/src/XunitContext/XunitContext.csproj
+++ b/src/XunitContext/XunitContext.csproj
@@ -5,12 +5,10 @@
     <Description>Extends xUnit to expose extra context and simplify logging.</Description>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="build\XunitContext.props" />
+    <None Remove="build\*" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="build\XunitContext.props">
-      <PackagePath>build\XunitContext.targets</PackagePath>
-    </Content>
+    <Content Include="build\XunitContext.props" PackagePath="build\XunitContext.props"/>
     <Content Include="build\XunitContext.targets" PackagePath="build\XunitContext.targets" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />


### PR DESCRIPTION
When updating to XUnitContext 3.1.0  nuget throws 
```
Access to the path '<nugetcache>\xunitcontext\3.1.0\build\XunitContext.targets' is denied.				.
```

This is due to it not being present in the nuget.  This PR corrects  XUnitContext.csproj so the file in included.