### PR TITLE
Revert "XunitContextBase: Return any captured exception (#336)"

### DIFF
--- a/src/Tests/UsingCurrentException.cs
+++ b/src/Tests/UsingCurrentException.cs
@@ -8,9 +8,6 @@ public class UsingCurrentException :
         Assert.True(false);
 
     [Fact]
-    public void Fails_CommonException() => throw new();
-
-    [Fact]
     public void Passes()
     {
     }
@@ -24,11 +21,11 @@ public class UsingCurrentException :
     {
         var contextTestException = Context.TestException;
         var methodName = Context.Test.TestCase.TestMethod.Method.Name;
-        if (methodName.Contains("Passes"))
+        if (methodName == "Passes")
         {
             Assert.Null(contextTestException);
         }
-        if (methodName.Contains("Fails"))
+        if (methodName == "Fails")
         {
             Assert.NotNull(contextTestException);
         }

--- a/src/XunitContext/Context.cs
+++ b/src/XunitContext/Context.cs
@@ -1,4 +1,4 @@
-using Xunit.Sdk;
+﻿using Xunit.Sdk;
 
 namespace Xunit;
 
@@ -65,9 +65,10 @@ public partial class Context
                 {
                     return targetInvocationException.InnerException;
                 }
+                return Exception;
             }
 
-            return Exception;
+            return null;
         }
     }
 


### PR DESCRIPTION
Reverts PR #336

I discovered that this ends up capturing exceptions thrown by underlying systems that do not have anything to do with the tests, so my original workaround mentioned in #335 is a better solution than the PR was.